### PR TITLE
Faster stdout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     InvalidPathName(std::ffi::OsString),
     Network(reqwest::Error),
     Encoding(std::str::Utf8Error),
+    Output(fmt::Error),
 }
 
 impl fmt::Display for Error {
@@ -22,6 +23,7 @@ impl fmt::Display for Error {
             InvalidPathName(err) => write!(fmt, "Invalid Path Name ({:?})", err),
             Network(err) => write!(fmt, "Error downloading the file ({})", err),
             Encoding(err) => write!(fmt, "Encoding error ({})", err),
+            Output(err) => write!(fmt, "Output error ({})", err),
         }
     }
 }
@@ -53,5 +55,11 @@ impl From<reqwest::Error> for Error {
 impl From<std::str::Utf8Error> for Error {
     fn from(err: std::str::Utf8Error) -> Self {
         Error::Encoding(err)
+    }
+}
+
+impl From<fmt::Error> for Error {
+    fn from(err: fmt::Error) -> Self {
+        Error::Output(err)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ mod checker;
 mod error;
 
 use crate::error::Result;
-use std::process;
+use std::{
+    io::{self, Write},
+    process,
+};
 
 fn main() -> Result<()> {
     let version = "2.0.2";
@@ -26,7 +29,9 @@ fn main() -> Result<()> {
         .output()
         .expect("failed to run binary");
 
-    println!("{}", std::str::from_utf8(&command.stdout)?);
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    writeln!(stdout, "{}", std::str::from_utf8(&command.stdout)?)?;
 
     process::exit(command.status.code().unwrap_or_default());
 }


### PR DESCRIPTION
Locking stdout results in faster runtimes for large outputs. This is based on #2 