### PR TITLE
Run more checks in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,4 +57,6 @@ jobs:
           command: test
 
      - name: Run editorconfig checker
-       run: cargo run -- --verbose
+       uses: actions-rs/cargo@v1
+       with:
+         command: test -- --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,17 +1,37 @@
 name: Rust
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
+    name: Build, Test and Lint
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run editorconfig checker
-      run: cargo run -- --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Check Formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all -- --check
+
+      - name: Clippy Linting
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,19 +16,22 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-
       - name: Run Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
 
       - name: Check Formatting
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all -- --check
+
+      - name: Install clippy
+        run: rustup component add clippy
 
       - name: Clippy Linting
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,8 @@ name: Rust
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Build, Test and Lint
+  lint:
+    name: Linting and Formatting Checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -15,11 +15,6 @@ jobs:
         with:
           toolchain: stable
           override: true
-
-      - name: Run Tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
 
       - name: Install rustfmt
         run: rustup component add rustfmt
@@ -38,3 +33,24 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  test:
+    name: Run Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           toolchain: stable
           override: true
+
       - name: Run Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+     - name: Run editorconfig checker
+       run: cargo run -- --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,13 +50,12 @@ jobs:
         with:
           toolchain: stable
           override: true
-
       - name: Run Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
 
-     - name: Run editorconfig checker
-       uses: actions-rs/cargo@v1
-       with:
-         command: test -- --verbose
+      - name: Run Editorconfig Checker
+        uses: actions-rs/cargo@v1
+        with:
+          command: run

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check Formatting
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: fmt
           args: --all -- --check
 
       - name: Install clippy

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -53,7 +53,7 @@ mod tests {
         #[cfg(not(debug_assertions))]
         let profile = "release";
 
-        let expected = format!("{}/target/{}/deps", pwd, profile);
+        let expected = format!("{}{sep}target{sep}{}{sep}deps", pwd, profile, sep = std::path::MAIN_SEPARATOR);
         let base_path = get_base_path(env::current_exe().unwrap()).unwrap();
         assert_eq!(expected, base_path)
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -53,7 +53,12 @@ mod tests {
         #[cfg(not(debug_assertions))]
         let profile = "release";
 
-        let expected = format!("{}{sep}target{sep}{}{sep}deps", pwd, profile, sep = std::path::MAIN_SEPARATOR);
+        let expected = format!(
+            "{}{sep}target{sep}{}{sep}deps",
+            pwd,
+            profile,
+            sep = std::path::MAIN_SEPARATOR
+        );
         let base_path = get_base_path(env::current_exe().unwrap()).unwrap();
         assert_eq!(expected, base_path)
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -109,8 +109,9 @@ mod tests {
 
         // unpack the file
         assert!(unpack(&archive_path, &extraction_dir.path()).is_ok());
-        let unpacked_content = fs::read_to_string(format!("{}/{}", extraction_dir.path().display(), file_name))
-            .expect("Cannot read extracted file");
+        let unpacked_content =
+            fs::read_to_string(format!("{}/{}", extraction_dir.path().display(), file_name))
+                .expect("Cannot read extracted file");
         // check that the extracted file contains the same as the initial file
         assert_eq!(initinal_content, unpacked_content);
     }


### PR DESCRIPTION
The following checks were added to the CI pipeline:

* formatting check (unformatted files cause the pipeline to fail)
* clippy lints (the [clippy](https://github.com/rust-lang/rust-clippy/) linter is executed and fails if lints are found)
* Run tests on Linux, Windows and Mac OS

I gues 3 to 4 minutes is still OK for the pipeline?