### PR TITLE
Enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ flate2 = "1.0.11"
 
 [dev-dependencies]
 tempfile = "3.1.0"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Link-time-optimization allows for smaller binaries by stripping more
unused code from external crates at compile time.

On Linux x64, the release build without LTO ist 7.9 MB, whereas the
build with LTO enabled is only 5.1 MB, that's a reduction of ~35% (if
I'm not mistaken)