### PR TITLE
Audit in CI

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,14 @@
+name: Security audit
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -4,8 +4,8 @@ on:
     - cron: '0 1 * * *'
   push:
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
 
 jobs:

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,9 +1,13 @@
 name: Security audit
 on:
+  schedule:
+    - cron: '0 0 0 * *'
   push:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+  pull_request:
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,5 +1,7 @@
 name: Security audit
 on:
+  schedule:
+    - cron: '0 1 * * *'
   push:
     paths:
       - '**/Cargo.toml'

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,7 +1,5 @@
 name: Security audit
 on:
-  schedule:
-    - cron: '0 0 0 * *'
   push:
     paths:
       - '**/Cargo.toml'

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -13,6 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: /usr/share/rust/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: /usr/share/rust/.cargo/git
+          key: ${{ runner.os }}-cargo-index
+
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "editorconfig-checker-rust"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "editorconfig-checker-rust"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "editorconfig-checker-rust"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Max Strübing <mxstrbng@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sys-info = "0.5.8"
-reqwest = "0.9.22"
-tar = "0.4.26"
 flate2 = "1.0.13"
+reqwest = "0.9.22"
+sys-info = "0.5.8"
+tar = "0.4.26"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "editorconfig-checker-rust"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Max Strübing <mxstrbng@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Run `cargo audit` every time the dependencies change, also every night at `01:00` and on PRs

- [x] on `Cargo.toml` or `Cargo.lock` change (see https://github.com/actions-rs/audit-check/issues/30 for why this did not work)
- [x] on PR
- [x] scheduled (only runs, if the CI config is on the default branch)