### PR TITLE
Use `XDG_CACHE_HOME` as download path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ notifications:
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
-  - cargo run -- --verbose && rm -r target/debug/bin
+  - cargo run -- --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1412,6 +1413,11 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
@@ -1574,3 +1580,4 @@ dependencies = [
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+"checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ sys-info = "0.5.8"
 reqwest = "0.9.22"
 tar = "0.4.26"
 flate2 = "1.0.13"
+xdg = "^2.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,7 +1,7 @@
 use crate::architecture::Architecture;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::ostype::OsType;
-use std::{fs, io, path::Path, path::PathBuf};
+use std::{fmt::Display, fs, io, path::Path};
 
 #[cfg(test)]
 mod tests {
@@ -9,7 +9,6 @@ mod tests {
     use crate::error::Result;
     use flate2::write::GzEncoder;
     use flate2::Compression;
-    use std::env;
     use std::env::consts;
     use std::fs::File;
     use tempfile::NamedTempFile;
@@ -50,32 +49,10 @@ mod tests {
     }
 
     #[test]
-    fn test_get_base_path() {
-        let pwd = env::current_dir().unwrap();
-        let pwd = pwd.display();
-
-        // this is a little hacky... it only works as long as debug assertions stay dissabled for
-        // release builds. but for now `cargo test` and `cargo test --release` work, when executed
-        // from the project root
-        #[cfg(debug_assertions)]
-        let profile = "debug";
-        #[cfg(not(debug_assertions))]
-        let profile = "release";
-
-        let expected = format!(
-            "{}{sep}target{sep}{}{sep}deps",
-            pwd,
-            profile,
-            sep = std::path::MAIN_SEPARATOR
-        );
-        let base_path = get_base_path(env::current_exe().unwrap()).unwrap();
-        assert_eq!(expected, base_path)
-    }
-
-    #[test]
     fn test_download() -> Result<()> {
         let base_url = generate_base_url("2.0.3");
-        let base_path = get_base_path(env::current_exe().unwrap()).unwrap();
+        let base_path = tempfile::tempdir().unwrap();
+        let base_path = base_path.path().display().to_string();
         let architecture = consts::ARCH.parse::<Architecture>()?;
         let os_type = consts::OS.parse::<OsType>()?;
 
@@ -157,11 +134,4 @@ pub fn unpack(tar_path: impl AsRef<Path>, base_path: impl AsRef<Path>) -> Result
     fs::remove_file(&tar_path)?;
 
     Ok(())
-}
-
-pub fn get_base_path(path: PathBuf) -> Result<String> {
-    path.parent()
-        .map(Path::display)
-        .map(|path| path.to_string())
-        .ok_or(Error::InvalidBasePath)
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -117,7 +117,7 @@ pub fn generate_base_url(version: &str) -> String {
     format!("{}/{}", base_url, version)
 }
 
-pub fn download(base_url: &str, base_path: &str, filename: &str) -> Result<()> {
+pub fn download(base_url: &str, base_path: impl Display, filename: impl Display) -> Result<()> {
     let filepath = format!("{}/{}.tar.gz", base_path, filename);
     let url = format!("{}/{}.tar.gz", base_url, filename);
     let mut resp = reqwest::get(&url)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     Network(reqwest::Error),
     Encoding(std::str::Utf8Error),
     Output(fmt::Error),
+    Xdg(xdg::BaseDirectoriesError),
 }
 
 impl fmt::Display for Error {
@@ -24,8 +25,14 @@ impl fmt::Display for Error {
             Network(err) => write!(fmt, "Error downloading the file ({})", err),
             Encoding(err) => write!(fmt, "Encoding error ({})", err),
             Output(err) => write!(fmt, "Output error ({})", err),
-            InvalidBasePath => write!(fmt, "Invalid Base Path"),
+            Xdg(err) => write!(fmt, "XdgError({})", err),
         }
+    }
+}
+
+impl From<xdg::BaseDirectoriesError> for Error {
+    fn from(err: xdg::BaseDirectoriesError) -> Self {
+        Error::Xdg(err)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,6 @@ pub enum Error {
     Network(reqwest::Error),
     Encoding(std::str::Utf8Error),
     Output(fmt::Error),
-    InvalidBasePath,
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
This fixes the problems described in #27 

- no more problems with non-writable download directories (except if a non-writable `XDG_CACHE_HOME` is configured, which makes no sense)
- it is possible to run multiple versions of the downloader/checker without path conflicts
- the downloader 'detects' if it has been updated but the downloaded checker is an older version
- the OS/user knows what files are not required for the downloader to work and can be removed safely (when running again, it will be rewritten to the cache, but that's how caches work)

On my system with the default XDG settings (`XDG_CACHE_HOME=$HOME/.cache`), the checker is stored as `$HOME/.cache/editorconfig-checker/2.0.3/bin/ec-linux-amd64`

Running `XDG_CACHE_HOME=$HOME/.cache2 cargo run` stores the binary in `$HOME/.cache2/editorconfig-checker/2.0.3/bin/ec-linux-amd64`, as expected.

Actually all the other `editorconfig-checker.*` projects might (should?) use this pattern, too (one might discuss the details about how the path should be structured) so different downloaders can share the already downloaded checker.

Closes #27 